### PR TITLE
The number text for a list should never be abbreviated via "..." #10

### DIFF
--- a/src/main/java/com/sandec/mdfx/impl/MDFXNodeHelper.java
+++ b/src/main/java/com/sandec/mdfx/impl/MDFXNodeHelper.java
@@ -249,7 +249,7 @@ public class MDFXNodeHelper extends VBox {
       Label label = new Label(text);
       label.getStyleClass().add("markdown-listitem-dot");
       label.getStyleClass().add("markdown-text");
-      label.setMinWidth(20);
+      label.setMinWidth(Region.USE_PREF_SIZE);
 
       HBox hbox = new HBox();
       hbox.getStyleClass().add("markdown-hbox1");


### PR DESCRIPTION
Replaced the call label.setMinWidth(20) with label.setMinWidth(Region.USE_PREF_SIZE).